### PR TITLE
Fix: Replace langchain_google_genai with browser_use.ChatGoogle

### DIFF
--- a/vibetest/mcp_server.py
+++ b/vibetest/mcp_server.py
@@ -37,7 +37,7 @@ async def start(url: str, num_agents: int = 3, headless: bool = False) -> str:
         return f"Error starting test: {str(e)}"
 
 @mcp.tool()
-def results(test_id: str) -> dict:
+async def results(test_id: str) -> dict:
     """Get the consolidated bug report for a test run.
     
     Args:
@@ -47,7 +47,7 @@ def results(test_id: str) -> dict:
         dict: Complete test results with detailed findings
     """
     try:
-        summary = summarize_bug_reports(test_id)
+        summary = await summarize_bug_reports(test_id)
         
         if "error" in summary:
             return summary


### PR DESCRIPTION
**Problem**: `ChatGoogleGenerativeAI` object has no field "ainvoke" error due to compatibility issues between `langchain_google_genai` and `browser_use` library.

**Solution**: Replace `langchain_google_genai.ChatGoogleGenerativeAI` with `browser_use.ChatGoogle`.

**Changes**:
- Updated imports to use `browser_use.ChatGoogle`
- Changed parameter from `google_api_key` to `api_key`
- Removed wrapper class (no longer needed)

Fixes [#6](https://github.com/browser-use/vibetest-use/issues/6)